### PR TITLE
Add icon definition to EconomyLite project in .poggit.yml

### DIFF
--- a/.poggit.yml
+++ b/.poggit.yml
@@ -4,6 +4,7 @@ branches:
 - main
 projects:
   EconomyLite:
+    icon: icon.png
     path: ""
     libs:
       - src: poggit/libasynql/libasynql


### PR DESCRIPTION
Include an `icon.png` reference to specify the project icon.